### PR TITLE
Fix panphon default encoding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ packages = [{ include = 'ru_transcript', from = 'src' }]
 
 [project]
 name = 'RuTranscript'
-version = '2.0.0'
+version = '2.0.1'
 description = 'A tool for phonetic transcription in russian'
 authors = [
     { name = 'Alexandra Badasyan', email = 'sashabadasyan@icloud.com' },

--- a/src/ru_transcript/_panphon_encoding.py
+++ b/src/ru_transcript/_panphon_encoding.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from importlib.resources import files
+
+import pandas as pd
+import panphon.featuretable
+from panphon.segment import Segment
+
+
+def patch_panphon_resource_encoding() -> None:
+    """Read panphon CSV resources as UTF-8 regardless of the process locale."""
+    if getattr(panphon.featuretable.FeatureTable, '_ru_transcript_utf8_patch', False):
+        return
+
+    def _read_bases(
+        _self: panphon.featuretable.FeatureTable, fn: str, weights: list[float]
+    ) -> tuple[list[tuple[str, Segment]], dict[str, Segment], list[str]]:
+        spec_to_int = {'+': 1, '0': 0, '-': -1}
+
+        with files('panphon').joinpath(fn).open(encoding='utf-8') as f:
+            df = pd.read_csv(f)
+
+        df['ipa'] = df['ipa'].apply(_self.normalize)
+
+        feature_names = list(df.columns[1:])
+        df[feature_names] = df[feature_names].map(lambda x: spec_to_int[x])
+        segments = [
+            (row['ipa'], Segment(feature_names, row[1:].to_dict(), weights=weights)) for (_, row) in df.iterrows()
+        ]
+        seg_dict = dict(segments)
+
+        return segments, seg_dict, feature_names
+
+    def _read_weights(_self: panphon.featuretable.FeatureTable, weights_fn: str) -> list[float]:
+        with files('panphon').joinpath(weights_fn).open(encoding='utf-8') as f:
+            df = pd.read_csv(f)
+        return df.iloc[0].astype(float).tolist()
+
+    panphon.featuretable.FeatureTable._read_bases = _read_bases  # noqa: SLF001
+    panphon.featuretable.FeatureTable._read_weights = _read_weights  # noqa: SLF001
+    panphon.featuretable.FeatureTable._ru_transcript_utf8_patch = True  # noqa: SLF001

--- a/src/ru_transcript/ru_transcript.py
+++ b/src/ru_transcript/ru_transcript.py
@@ -9,6 +9,7 @@ from openpyxl.workbook.workbook import Workbook
 from tps import download, find
 from tps import modules as md
 
+from ._panphon_encoding import patch_panphon_resource_encoding
 from .consts import (
     EPITRAN_RUSSIAN_CYRILLIC,
     FIRST_SILENT,
@@ -48,6 +49,8 @@ from .tools import (
     voiced_ts,
     vowels,
 )
+
+patch_panphon_resource_encoding()
 
 snowball = SnowballStemmer(RUSSIAN_LANGUAGE)
 nlp = spacy.load(SPACY_RUSSIAN_MODEL, disable=SPACY_DISABLED_PIPELINES)

--- a/src/ru_transcript/ru_transcript.py
+++ b/src/ru_transcript/ru_transcript.py
@@ -1,13 +1,13 @@
+import importlib
 import warnings
 from pathlib import Path
 
 import epitran
+import nltk
 import spacy
 from nltk.stem.snowball import SnowballStemmer
 from openpyxl import load_workbook
 from openpyxl.workbook.workbook import Workbook
-from tps import download, find
-from tps import modules as md
 
 from ._panphon_encoding import patch_panphon_resource_encoding
 from .consts import (
@@ -51,6 +51,24 @@ from .tools import (
 )
 
 patch_panphon_resource_encoding()
+
+_nltk_download = nltk.download
+
+
+def _skip_punkt_download(package: str, *args: object, **kwargs: object) -> bool:
+    if package == 'punkt':
+        return False
+    return _nltk_download(package, *args, **kwargs)
+
+
+try:
+    nltk.download = _skip_punkt_download
+    _tps = importlib.import_module('tps')
+    md = importlib.import_module('tps.modules')
+    download = _tps.download
+    find = _tps.find
+finally:
+    nltk.download = _nltk_download
 
 snowball = SnowballStemmer(RUSSIAN_LANGUAGE)
 nlp = spacy.load(SPACY_RUSSIAN_MODEL, disable=SPACY_DISABLED_PIPELINES)

--- a/tests/test_panphon_encoding.py
+++ b/tests/test_panphon_encoding.py
@@ -1,0 +1,45 @@
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class TestPanphonEncoding(unittest.TestCase):
+    def test_panphon_feature_table_reads_utf8_with_ascii_locale(self):
+        project_root = Path(__file__).resolve().parents[1]
+        patch_module = project_root / 'src' / 'ru_transcript' / '_panphon_encoding.py'
+        code = textwrap.dedent(
+            f"""
+            import importlib.util
+
+            spec = importlib.util.spec_from_file_location('panphon_encoding_patch', {str(patch_module)!r})
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            module.patch_panphon_resource_encoding()
+
+            import panphon.featuretable
+
+            panphon.featuretable.FeatureTable()
+            """
+        )
+
+        env = os.environ.copy()
+        env['LC_ALL'] = 'C'
+        env['PYTHONUTF8'] = '0'
+
+        result = subprocess.run(
+            [sys.executable, '-c', code],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes incorrect default encoding when `panphon` reads bundled CSV resources in non-UTF-8 environments.

The issue affected `panphon` data files used through `epitran`, where CSV resources could be opened with the process default encoding instead of UTF-8 and fail with `UnicodeDecodeError`.

## Changes

- Added a compatibility patch for `panphon.FeatureTable` resource loading to explicitly read CSV files with `encoding='utf-8'`.
- Applied the patch before initializing `epitran.Epitran`.
- Added a regression test that verifies `panphon.FeatureTable()` works under `LC_ALL=C` and `PYTHONUTF8=0`.
- Suppressed noisy `tps` import-time attempts to download `nltk` `punkt`, which could print SSL/network errors during import.
- Bumped package version to `2.0.1`.

## Notes

This keeps the current `epitran 1.35.1` / `panphon 0.22.2` dependency setup and protects the package until the encoding fix is available upstream in `panphon`.